### PR TITLE
Update Dockerfile to two-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,57 @@
-# syntax=docker/dockerfile:1-labs
-FROM nvidia/cuda:12.1.0-devel-ubuntu22.04
+# 使用NVIDIA CUDA 12.4作为基础镜像
+FROM nvidia/cuda:12.4.0-devel-ubuntu22.04 AS builder
 
-# Update Apt repositories
-RUN apt-get update 
+# 设置工作目录和环境变量  
+WORKDIR /app
+ENV DEBIAN_FRONTEND=noninteractive  
 
-# Install and configure Python
-RUN apt-get -y --no-install-recommends install wget build-essential python3.10 python3-pip
-RUN update-alternatives --install /usr/bin/python  python /usr/bin/python3.10 1
-RUN pip install setuptools streamlit-chat
+# 安装必要的依赖，clone代码并编译，所有操作在一个RUN命令中完成
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    cmake \
+    g++ \
+    git \
+    libnuma-dev \
+    make \
+    python3 \
+    python3-pip \
+    wget \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    # clone 并编译 fastllm
+    && git clone --depth=1 https://github.com/ztxz16/fastllm.git \
+    && cd fastllm \
+    # 下面这行 CMAKE_CUDA_ARCHITECTURES 与 CUDA_ARCH 在此不能替换使用，可能是Cmake的bug，使用CUDA_ARCH即可
+    && bash install.sh -DUSE_CUDA=ON -DUSE_NUMA=ON -DCUDA_ARCH=89 -DCMAKE_CUDA_COMPILER=$(which nvcc) \
+    # 清理编译临时文件
+    && rm -rf build/CMakeFiles build/*.o
 
-ENV WORKDIR /fastllm
+# 多阶段构建：创建最终镜像
+FROM nvidia/cuda:12.4.0-runtime-ubuntu22.04
 
-# Install cmake
-RUN wget -c https://cmake.org/files/LatestRelease/cmake-3.28.3-linux-x86_64.sh && bash ./cmake-3.28.3-linux-x86_64.sh  --skip-license --prefix=/usr/
+# 设置工作目录和环境变量
+WORKDIR /app
+ENV DEBIAN_FRONTEND=noninteractive \
+    PATH="/app/fastllm/build/bin:${PATH}" \
+    FASTLLM_CACHEDIR="/data"
 
-WORKDIR $WORKDIR
-ADD . $WORKDIR/
+# 安装运行时依赖并创建数据目录，所有操作在一个RUN命令中
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libnuma1 \
+    python3 \
+    python3-pip \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    # 创建数据目录
+    && mkdir -p /data \
+    && chmod 777 /data
 
-RUN mkdir $WORKDIR/build && cd build && cmake .. -DUSE_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=native && make -j && cd tools && python setup.py install
+# 从构建阶段复制编译好的FastLLM，只复制必要文件
+COPY --from=builder /app/fastllm /app/fastllm
+COPY --from=builder /usr/local/lib/python3*/dist-packages/fastllm* /usr/local/lib/python3.10/dist-packages/
 
-CMD /fastllm/build/webui -p /models/chatglm2-6b-int8.flm
+# 健康检查
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD python3 -c "import ftllm; print('fastllm health check passed')" || exit 1
+
+# 容器启动时运行的命令  
+CMD ["bash"]


### PR DESCRIPTION
This commit updates the Dockerfile to use a two-stage build process, based on your provided reference.

The first stage (builder) compiles the fastllm application. The second stage creates a lean runtime image by copying the compiled artifacts and necessary runtime dependencies.

The Dockerfile now uses nvidia/cuda:12.4.0 images and sets up the environment for running fastllm, including setting FASTLLM_CACHEDIR to /data for model mounting and CMD ["bash"] to keep the container running.

A build test was attempted but failed due to disk space limitations in the build environment. The Dockerfile content has been verified against your reference.